### PR TITLE
Update LICENSE.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ install(
         "./"
     )
 
-# Create target import scripts so other cmake projects can use epanet libraries
+# Install target import scripts so other cmake projects can use epanet libraries
 install(
     EXPORT
         epanet2Targets

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,10 +1,23 @@
 MIT License
 
 Portions Copyright (c) 2016-2019 see AUTHORS
-Portions Copyright (c) 2000-2008, 2019 U.S. Federal Government (in countries where recognized)
+Portions Copyright (c) 2000-2008, 2019 U.S. Federal Government (in countries
+where recognized)
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,8 @@
 MIT License
 
-Portions Copyright (c) 2016, 2019 see AUTHORS
+Portions Copyright (c) 2016-2019 see AUTHORS
+Portions Copyright (c) 2000-2019 U.S. Federal Government (in countries where recognized)
+
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,23 +1,10 @@
 MIT License
 
 Portions Copyright (c) 2016-2019 see AUTHORS
-Portions Copyright (c) 2000-2019 U.S. Federal Government (in countries where recognized)
+Portions Copyright (c) 2000-2008, 2019 U.S. Federal Government (in countries where recognized)
 
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/scripts/app-config.cmd
+++ b/scripts/app-config.cmd
@@ -47,7 +47,7 @@ IF [%3]==[] ( set "BUILD_ID=unknown"
 
 :: determine version
 for /F "tokens=1" %%v in ( 'git rev-parse --short HEAD' ) do ( set "VERSION=%%v" )
-
+if not defined VERSION ( echo "ERROR: VERSION could not be determined" & exit /B 1 )
 
 echo {
 echo     "name" : "epanet",

--- a/scripts/make.cmd
+++ b/scripts/make.cmd
@@ -18,6 +18,7 @@
 ::      https://www.boost.org/users/download/
 ::
 ::  Environment Variables:
+::    BOOST_ROOT - defaults to C:\local\boost_1_67_0
 ::    BUILD_HOME - defaults to build
 ::
 ::  Optional Arguments:
@@ -69,6 +70,8 @@ if NOT [%1]==[] (
   goto :loop
 )
 
+if not defined BOOST_ROOT ( set "BOOST_ROOT=C:\local\boost_1_67_0" )
+
 
 :: if generator has changed delete the build folder
 if exist %BUILD_HOME% (
@@ -87,7 +90,7 @@ if exist %BUILD_HOME% (
 :: perform the build
 cd %BUILD_HOME%
 if %TESTING% EQU 1 (
-  cmake -G"%GENERATOR%" -DBUILD_TESTS=ON -DBOOST_ROOT=C:\local\boost_1_67_0 ..^
+  cmake -G"%GENERATOR%" -DBUILD_TESTS=ON -DBOOST_ROOT=%BOOST_ROOT% ..^
   && cmake --build . --config Debug^
   & echo. && ctest -C Debug --output-on-failure
 ) else (

--- a/tests/shared/CMakeLists.txt
+++ b/tests/shared/CMakeLists.txt
@@ -12,7 +12,7 @@ target_include_directories(test_cstrhelper
     PUBLIC
         ${Boost_INCLUDE_DIRS}
     PRIVATE
-        ${CMAKE_SOURCE_DIR}/
+        ${CMAKE_SOURCE_DIR}/src
     )
 
 target_link_libraries(test_cstrhelper
@@ -27,7 +27,7 @@ add_executable(test_errormanager
 
 target_include_directories(test_errormanager
     PRIVATE
-        ${CMAKE_SOURCE_DIR}/
+        ${CMAKE_SOURCE_DIR}/src
     )
 
 target_link_libraries(test_errormanager
@@ -42,7 +42,7 @@ add_executable(test_filemanager
 
 target_include_directories(test_filemanager
     PRIVATE
-        ${CMAKE_SOURCE_DIR}/
+        ${CMAKE_SOURCE_DIR}/src
     )
 
 target_link_libraries(test_filemanager


### PR DESCRIPTION
Updating copyright notice to more accurately reflect
1) derivative nature of work
2) role of US Federal Government
3) more uniform placement of work under MIT License

Under review by Office of General Counsel (OGC)

See Issue #47 